### PR TITLE
Use default compile/javadoc plugin configuration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,10 @@
     </scm>
 
     <properties>
-        <jdk.min.version>11</jdk.min.version>
-        <jdk.release.version>11</jdk.release.version>
         <jdk.runtime.args>--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jdk.runtime.args>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+
         <version.jakarta.annotation>1.3.5</version.jakarta.annotation>
         <version.net.jcip.annotations>1.0</version.net.jcip.annotations>
         <version.org.apache.httpcomponents>5.1.3</version.org.apache.httpcomponents>
@@ -65,25 +66,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <goals>
-                    <goal>compile</goal>
-                </goals>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <release>${jdk.release.version}</release>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
                     <artifactItems>
@@ -93,13 +75,6 @@
                             <version>${project.version}</version>
                         </artifactItem>
                     </artifactItems>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <source>${jdk.release.version}</source>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Fixes test compile using 8 instead of 11.